### PR TITLE
fix: input flag (-i)

### DIFF
--- a/clairvoyance/cli.py
+++ b/clairvoyance/cli.py
@@ -126,8 +126,10 @@ def cli(argv: Optional[List[str]] = None) -> None:
     # remove wordlist items that don't conform to graphQL regex github-issue #11
     if args.validate:
         wordlist_parsed = [w for w in wordlist if re.match(r'[_A-Za-z][_0-9A-Za-z]*', w)]
-        logging.info(f'Removed {len(wordlist) - len(wordlist_parsed)} items from Wordlist, to conform to name regex. '
-                     f'https://spec.graphql.org/June2018/#sec-Names')
+        logging.info(
+            f'Removed {len(wordlist) - len(wordlist_parsed)} items from Wordlist, to conform to name regex. '
+            f'https://spec.graphql.org/June2018/#sec-Names'
+        )
         wordlist = wordlist_parsed
 
     asyncio.run(

--- a/clairvoyance/utils.py
+++ b/clairvoyance/utils.py
@@ -28,7 +28,6 @@ def parse_args(args: List[str]) -> argparse.Namespace:
         '-i',
         '--input-schema',
         metavar='<file>',
-        type=argparse.FileType('r'),
         help='Input file containing JSON schema which will be supplemented with obtained information',
     )
     parser.add_argument(


### PR DESCRIPTION
-i flag was broken, resulting in 
```BASH
with open(input_schema_path, 'r', encoding='utf-8') as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: expected str, bytes or os.PathLike object, not TextIOWrapper
```