### PR TITLE
fix: recursive schemas loops

### DIFF
--- a/clairvoyance/graphql.py
+++ b/clairvoyance/graphql.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 import json
 from typing import Any, Dict, List, Optional, Set
 


### PR DESCRIPTION
Clairvoyance was ending up in an infinite loop if the schema had loops (for instance: User -> friends -> [User] -> friends -> ...).
Implemented a DFS algorithm in the `get_path_from_root` method that fixes the issue (thanks to keeping track of visited nodes).
There might still be some edge cases where clairvoyance cannot resolve a full path from a type to a root type (query, mutation or subscription) but it will now raise an error rather than ending up in an infinite loop.
